### PR TITLE
Fix for deprecation warning

### DIFF
--- a/custom_components/pikvm_ha/utils.py
+++ b/custom_components/pikvm_ha/utils.py
@@ -1,4 +1,5 @@
 import voluptuous as vol
+from homeassistant.helpers.translation import async_get_translations
 from .const import CONF_URL, CONF_USERNAME, CONF_PASSWORD, DEFAULT_USERNAME, DEFAULT_PASSWORD
 
 def format_url(input_url):
@@ -31,7 +32,7 @@ def find_existing_entry(self, serial):
 
 async def get_translations(hass, language, domain):
     """Get translations for the given language and domain."""
-    translations = await hass.helpers.translation.async_get_translations(language, "config")
+    translations = await async_get_translations(language, "config")
     def translate(key, default):
         return translations.get(f"component.{domain}.{key}", default)
     return translate


### PR DESCRIPTION
These usages were deprecated in [2024.5](https://developers.home-assistant.io/blog/2024/03/30/deprecate-hass-helpers/), fixes #3 

I can't verify this locally because I cannot setup the integration (see issue #2 ), but it's a fairly simple fix that should be reasonably backwards compatible.