### PR TITLE
Handle missing MSD size/free keys in V4

### DIFF
--- a/custom_components/pikvm_ha/sensors/pikvm_msd_storage_sensor.py
+++ b/custom_components/pikvm_ha/sensors/pikvm_msd_storage_sensor.py
@@ -1,6 +1,10 @@
 """Support for PiKVM MSD storage sensor."""
 
+import logging
+
 from ..sensor import PiKVMBaseSensor
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class PiKVMSDStorageSensor(PiKVMBaseSensor):
@@ -17,6 +21,7 @@ class PiKVMSDStorageSensor(PiKVMBaseSensor):
             "%",
             "mdi:database",
         )
+
     @property
     def state(self):
         data = self.coordinator.data.get("msd", {}).get("storage", {})
@@ -34,12 +39,17 @@ class PiKVMSDStorageSensor(PiKVMBaseSensor):
         storage_data = self.coordinator.data["msd"]["storage"]
         images = self.coordinator.data["msd"]["storage"]["images"]
         if storage_data:
-            attributes["total_size_mb"] = round(storage_data["size"] / (1024 * 1024), 2)
-            attributes["free_size_mb"] = round(storage_data["free"] / (1024 * 1024), 2)
-            attributes["used_size_mb"] = round(
-                (storage_data["size"] - storage_data["free"]) / (1024 * 1024), 2
-            )
-            attributes["percent_free"] = self.state
+            if "size" in storage_data:
+                attributes["total_size_mb"] = round(storage_data["size"] / (1024 * 1024), 2)
+            if "free" in storage_data:
+                attributes["free_size_mb"] = round(storage_data["free"] / (1024 * 1024), 2)
+            if "free" in storage_data and "size" in storage_data:
+                attributes["used_size_mb"] = round(
+                    (storage_data["size"] - storage_data["free"]) / (1024 * 1024), 2
+                )
+            state = self.state
+            if state is not None:
+                attributes["percent_free"] = self.state
         if images and len(images.items()) < 20:
             for image, details in images.items():
                 attributes[image] = details["size"]


### PR DESCRIPTION
Builds on the work in commit a6264b2 by adding missing logger import and adding key verification for `extra_state_attributes()` as well.

Also resolves #13, making this integration work for PiKVM V4, which no longer has the `free` and `size` keys at the top level of the MSD data.

An alternative to this fix would be to pull it from `"parts"`/`""`, using those values (or possibly summing up the values for all entries under `"parts"`). But I'm not sure if that is correct or not (though it looks like it is, at least for the V3 PiKVM I have (Geekworm KVM-A8).